### PR TITLE
Fix numpy type, add png-only bin-only and no processing flags, fix binary w to wb

### DIFF
--- a/gxs700/im_util.py
+++ b/gxs700/im_util.py
@@ -43,10 +43,10 @@ def average_imgs(imgs, scalar=None):
         scalar = 1.0
     scalar = scalar / len(imgs)
 
-    statef = np.zeros((height, width), np.float)
+    statef = np.zeros((height, width), float)
     for im in imgs:
         assert (width, height) == im.size
-        statef = statef + scalar * np.array(im, dtype=np.float)
+        statef = statef + scalar * np.array(im, dtype=float)
 
     return statef, npf2im(statef)
 

--- a/gxs700/raw_main.py
+++ b/gxs700/raw_main.py
@@ -37,7 +37,7 @@ def run(
 
         if bin_out:
             print('Writing %s' % binfn)
-            open(binfn, 'w').write(imgb)
+            open(binfn, 'wb').write(imgb)
 
         if png_out:
             print('Decoding image...')
@@ -102,5 +102,4 @@ def main():
         int_t=args.int_t,
         ctr_thresh=args.ctr_thresh,
         bin_thresh=args.bin_thresh)
-
-
+        

--- a/main.py
+++ b/main.py
@@ -33,6 +33,9 @@ def main():
         '--hist-eq-roi', default="258,258,516,516", help='hist eq x1,y1,x2,y2')
     add_bool_arg(parser, "--hist-eq", default=True)
     add_bool_arg(parser, "--raw", default=False)
+    add_bool_arg(parser, "--png", default=True)
+    add_bool_arg(parser, "--bin", default=False)
+    add_bool_arg(parser, "--process", default=True)
     parser.add_argument('fn_out', default=None, nargs='?', help='')
     args = parser.parse_args()
 
@@ -65,18 +68,21 @@ def main():
             imgn=args.n,
             int_t=args.int_t,
             force_trig=force_trig,
+            png_out=args.png,
+            bin_out=args.bin,
             xr=xr)
     # notably ^C can cause this
     finally:
         xr and xr.beam_off()
 
-    process_main.run(
-        outdir,
-        args.fn_out,
-        cal_dir=args.cal_dir,
-        hist_eq=args.hist_eq,
-        raw=args.raw,
-        hist_eq_roi=im_util.parse_roi(args.hist_eq_roi))
+    if args.process:    
+        process_main.run(
+            outdir,
+            args.fn_out,
+            cal_dir=args.cal_dir,
+            hist_eq=args.hist_eq,
+            raw=args.raw,
+            hist_eq_roi=im_util.parse_roi(args.hist_eq_roi))
 
     print("done")
 


### PR DESCRIPTION
1. Numpy's "np.float" is deprecated. Replaced with "float"
2. There were no flags to only write out binaries and disable pngs and processing
3. Binary writing needed "wb" flag instead of "w"